### PR TITLE
[change]Headerエリアのリンクのタグを変更

### DIFF
--- a/src/components/Areas/Header.jsx
+++ b/src/components/Areas/Header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Tab from '../Elements/Tab';
+
 import '../../styles/Areas/Header.css';
 
 const Header = () => {
@@ -9,12 +9,12 @@ const Header = () => {
             <div className='headerTitle'>FUNPUT</div>
             <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet"></link>
             <div >
-                <i className="fas fa-home fa-lg "></i>
-                <Tab name={'HOME'} url={"/home"} />
-                <i className="fas fa-file-export"></i>
-                <Tab name={'投稿'} url={"/post"} />
-                <i className="far fa-heart"></i>
-                <Tab name={'いいね'} url={"/like"} />
+                <i className="fas fa-home fa-2x "></i>
+                <a href={"/home"} >HOME</a>
+                <i className="fas fa-file-export fa-2x"></i>
+                <a href={"/post"} >投稿</a>
+                <i className="far fa-heart fa-2x"></i>
+                <a href={"/like"} >いいね</a>
             </div>
         </div >
     )

--- a/src/components/Elements/Tab.jsx
+++ b/src/components/Elements/Tab.jsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom'
 import '../../styles/Elements/Tab.css'
 
 const Tab = (props) => {
-    const { name, url } = props;
+    const { url, name } = props;
     const history = useHistory();
 
     const handleClick = () => {

--- a/src/styles/Areas/Header.css
+++ b/src/styles/Areas/Header.css
@@ -1,21 +1,32 @@
 .headerTitle{
 text-align: left;
-font-size: 30px;
+font-size: 40px;
+font-weight: bold;
 color: coral;
+margin-top: 20px;
 }
 
 .fa-lg{
   position: relative;
-  top: 70px;
+  margin-top: 45px;
 }
 
 .fa-file-export{
   position: relative;
-  top: 70px;
+  margin-left: 20px;
+  margin-top: 45px;
 }
 
 .fa-heart{
   position: relative;
-  top: 70px;
+  margin-left: 20px;
+  margin-top: 45px;
+ 
 }
 
+a {
+  text-decoration: none;
+  font-size: 30px;
+  margin-top:45px;
+  }
+  

--- a/src/styles/Elements/Tab.css
+++ b/src/styles/Elements/Tab.css
@@ -1,5 +1,5 @@
 .tabSpace {
   position: relative;
   top: 70px;
-  margin-right :30px;
+  margin-right :100px;
   }


### PR DESCRIPTION
【変更点】
Components/Area/Header.jsxを変更。前までリンク部分が文字として認識されていたのを修正。
【確認項目】
文字にカーソルを当てたとき文字ではなくリンクとして認識されている。ページ遷移できる。